### PR TITLE
Add --directory flag and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/btipling/fe"
 license = "Apache-2.0"
 
 [dependencies]
-clap = { version = "~2.19.0", features = ["yaml"] }
-glob = "0.2.11"
-regex = "0.2"
-term-painter = "0.2.3"
+clap = { version = "2.33.3", features = ["yaml"] }
+glob = "0.3.0"
+regex = "1.4.1"
+term-painter = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fe"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Bjorn Tipling <bjorn@ambientchill.com>"]
 description = "Fe is a sophisticated, yet simple to use file listing utility. Use Fe to list files in a directory or to recursively find files by their names using a fuzzy pattern. Fe's speeds are comparable to find, and often times faster."
 documentation = "https://github.com/btipling/fe/blob/master/README.md"

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -1,5 +1,5 @@
 name: fe
-version: "1.0.3"
+version: "1.0.4"
 author: Bjorn Tipling <bjorn@ambientchill.com>
 about: Helps you find files with a fuzzy search.
 args:

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -3,6 +3,11 @@ version: "1.0.3"
 author: Bjorn Tipling <bjorn@ambientchill.com>
 about: Helps you find files with a fuzzy search.
 args:
+    - search_dir:
+        short: d
+        long: directory
+        help: Specify the directory to search
+        takes_value: true
     - insensitive:
         short: i
         long: insensitive

--- a/src/fileinfo.rs
+++ b/src/fileinfo.rs
@@ -38,8 +38,8 @@ const S_IXOTH: mode_t = 1; // Execute/search permission, others.
 impl FileInfo {
 
     pub fn new(path: &path::Path) -> Result<FileInfo, io::Error> {
-        let metadata = try!(path.metadata());
-        let l_metadata = try!(path.symlink_metadata());
+        let metadata = path.metadata()?;
+        let l_metadata = path.symlink_metadata()?;
         let mode = FileInfo::mode(&metadata);
         let l_mode = FileInfo::mode(&l_metadata);
         return Ok(FileInfo {

--- a/src/find.rs
+++ b/src/find.rs
@@ -87,7 +87,7 @@ pub fn find (pattern: &str, options: &super::Options) {
     // subdirectories.
     let mut rule_sets = vec![ignore::RuleSet::new_default()];
     let dir = Dir {
-        path: path::PathBuf::from("./"),
+        path: path::PathBuf::from(&options.search_dir),
         rule_index: 0,
     };
     let mut dirs = vec![dir];

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -99,7 +99,7 @@ impl RuleSet {
                 require_literal_separator: false,
                 require_literal_leading_dot: false
             };
-            if rule_set_pattern.pattern.matches_with(path, &match_options) {
+            if rule_set_pattern.pattern.matches_with(path, match_options) {
                 v(format!("{} is ignored because it matches {}", path, rule_set_pattern.pattern), options);
                 return true;
             } else {

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -37,7 +37,7 @@ impl RuleSetPattern {
         if path.len() == 0 {
             return Err(RuleSetError::NoLength);
         }
-        let pattern = try!(Pattern::new(path).map_err(RuleSetError::Pattern));
+        let pattern = Pattern::new(path).map_err(RuleSetError::Pattern)?;
         Ok(RuleSetPattern {
             pattern: pattern,
             is_dir: false,
@@ -60,13 +60,13 @@ impl RuleSet {
 
     pub fn new (ignore_path: &path::Path, options: &super::Options) -> Result<RuleSet, IgnoreError> {
 
-        let f = try!(fs::File::open(ignore_path).map_err(IgnoreError::Io));
+        let f = fs::File::open(ignore_path).map_err(IgnoreError::Io)?;
         v(format!("Found {:?} an ignore file.", ignore_path), options);
 
         let buffer = io::BufReader::new(&f);
         let mut rules: Vec<RuleSetPattern> = vec![];
         for line in buffer.lines() {
-            let l = try!(line.map_err(IgnoreError::Io));
+            let l = line.map_err(IgnoreError::Io)?;
             if l.starts_with('#') {
                 continue;
             }
@@ -84,7 +84,7 @@ impl RuleSet {
     }
 
     pub fn extend (rule_set: &RuleSet, ignore_path: &path::Path, options: &super::Options) -> Result<RuleSet, IgnoreError> {
-        let mut new_set = try!(RuleSet::new(ignore_path, options));
+        let mut new_set = RuleSet::new(ignore_path, options)?;
         new_set.rules.extend(rule_set.rules.clone());
         Ok(new_set)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ pub struct Options {
     search_names_only: bool,
     no_colors: bool,
     search_type: SearchType,
+    search_dir: String,
 }
 
 fn main() {
@@ -48,8 +49,8 @@ fn main() {
         search_names_only: matches.is_present("name"),
         no_colors: matches.is_present("plain"),
         search_type: search_type,
+        search_dir: matches.value_of("search_dir").unwrap_or("./").to_string(),
     };
-
 
     // Unwrap in pattern is safe, clap guarantees it.
     let pattern = match matches.value_of("pattern") {


### PR DESCRIPTION
I find `fe` to be really useful, though it would be far more so if one could specify the directory rather than having to `cd` to the dir one wishes to search.

Thus I added this ability and am opening this pull request so others can benefit from this change as well.